### PR TITLE
Cache not working due to old Cache version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@actions/cache": "^3.2.3",
+    "@actions/cache": "^4.0.0",
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
     "@actions/glob": "^0.4.0",


### PR DESCRIPTION
Currently, the caching for this Action does not work, as Github has decommissioned support for versions <4 (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts).

Dependency update:

* Updated the `@actions/cache` dependency from version `^3.2.3` to `^4.0.0` in `package.json`.