### PR TITLE
Fix default `cache-dependency-path`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,9 @@ inputs:
     default: true
   cache-dependency-path:
     description: A multiline list of globs to use to derive the '~/.fontist' cache key. The default is 'manifest.yml' and 'manifest.yaml'. If no files are matched at runtime then the '~/.fontist' folder will not be cached.
-    default: manifest.y{a,}ml
+    default: |
+      manifest.yml
+      manifest.yaml
 
 outputs:
   fontist-version:


### PR DESCRIPTION
This PR replaces the "shell-like" pattern `manifest.y{a,}ml` with multiline string for [proper glob usage](https://github.com/actions/toolkit/tree/main/packages/glob#glob-behavior).