### PR TITLE
feat: add support for private formula repositories

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -16,6 +16,10 @@ on:
       - .github/**
       - "!.github/workflows/test-action.yml"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -39,3 +43,17 @@ jobs:
         with:
           cache-dependency-path: test.yml
       - run: fontist manifest install test.yml
+
+  test-private-repos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run build
+      - uses: ./
+        with:
+          github-token: ${{ secrets.FONTIST_CI_PAT_TOKEN }}
+          formula-repos: |
+            metanorma https://github.com/metanorma/fontist-formulas-private.git
+      - run: fontist install "BSI Gesta"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Setup Fontist
 
+[![Test action](https://github.com/fontist/setup-fontist/actions/workflows/test-action.yml/badge.svg)](https://github.com/fontist/setup-fontist/actions/workflows/test-action.yml)
+
 🔠 Install [Fontist](https://www.fontist.org/) for GitHub Actions
 
 <table align=center><td>
@@ -11,24 +13,68 @@
 
 </table>
 
-💎 Uses Ruby to install the fontist Ruby gem \
-🟦 Works with Windows \
-🐧 Works with Ubuntu \
-🍎 Works with macOS \
-⚡ Caches installation in `$RUNNER_TOOL_CACHE` and/ior the workflow cache \
-📐 Caches `~/.fontist` font installs by default using `manifest.yml`
+This action installs [Fontist](https://www.fontist.org/), a cross-platform font package manager, on GitHub Actions runners. It handles multi-level caching to speed up your CI workflows.
 
-## Usage
+- 💎 Uses Ruby to install the fontist Ruby gem
+- 🟦 Works with Windows
+- 🐧 Works with Ubuntu
+- 🍎 Works with macOS
+- ⚡ Caches installation in `$RUNNER_TOOL_CACHE` and/or the workflow cache
+- 📐 Caches `~/.fontist` font installs by default using `manifest.yml`
+- 🔐 Supports private formula repositories with GitHub token authentication
 
-![GitHub Actions](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub+Actions&color=2088FF&logo=GitHub+Actions&logoColor=FFFFFF&label=)
-![GitHub](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub&color=181717&logo=GitHub&logoColor=FFFFFF&label=)
+# Usage
 
-**🚀 Here's what you're after:**
+<!-- start usage -->
+```yaml
+- uses: fontist/setup-fontist@v2
+  with:
+    # The version of Fontist to install. This can be an exact version like
+    # '1.10.0' or a semver range such as '1.x' or '~1.15.0'.
+    # Default: latest
+    fontist-version: ''
 
-```yml
+    # GitHub token for accessing private formula repositories.
+    # Default: ${{ github.token }}
+    github-token: ''
+
+    # A multiline list of private Fontist formula repositories to set up.
+    # Each line should be in format: NAME URL
+    # Example:
+    #   acme https://github.com/acme/fontist-formulas.git
+    #   corp https://github.com/corp/fonts.git
+    # Default: ''
+    formula-repos: ''
+
+    # Whether to use @actions/cache to cache things in the GitHub workflow cache.
+    # Default: true
+    cache: ''
+
+    # A multiline list of globs to use to derive the '~/.fontist' cache key.
+    # If no files are matched at runtime then the '~/.fontist' folder will
+    # not be cached.
+    # Default: |
+    #   manifest.yml
+    #   manifest.yaml
+    cache-dependency-path: ''
+```
+<!-- end usage -->
+
+# Scenarios
+
+- [Basic usage](#basic-usage)
+- [Install specific version](#install-specific-version)
+- [Use with manifest file](#use-with-manifest-file)
+- [Private formula repositories](#private-formula-repositories)
+- [Disable caching](#disable-caching)
+- [Custom cache key](#custom-cache-key)
+
+## Basic usage
+
+```yaml
 on: push
 jobs:
-  job:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,40 +82,130 @@ jobs:
       - run: fontist install "Fira Code"
 ```
 
-💡 You can use `fontist manifest-install manifest.yml` to install fonts listed in a manifest file similar to `package.json`, `requirements.txt`, and `Cargo.toml`.
+## Install specific version
 
-### Inputs
+```yaml
+- uses: fontist/setup-fontist@v2
+  with:
+    fontist-version: '1.10.0'  # or '1.x' or '~1.15.0'
+```
 
-- **`fontist-version`:** The version of Fontist to install. This can be an exact version lile `1.10.0` or a semver range such as `1.x` or `~1.15.0`. The default value is `latest`.
+## Use with manifest file
 
-- **`cache`:** Whether or not to use [@actions/cache](https://www.npmjs.com/package/@actions/cache) to cache things in the GitHub workflow cache. This is enabled by default.
+Create a `manifest.yml` file in your repository:
 
-- **`cache-dependency-path`:** A multiline list of globs to use to derive the `~/.fontist` cache key. The default is `manifest.yml` and `manifest.yaml`. If no files are matched at runtime then the `~/.fontist` folder will not be cached.
+```yaml
+# manifest.yml
+Fira Code:
+- Regular
+- Bold
+Source Sans Pro:
+- Regular
+```
 
-### Outputs
+Then use it in your workflow:
 
-- **`fontist-version`:** The version of Fontist that was installed. This will be something like `1.10.0` or similar.
+```yaml
+- uses: fontist/setup-fontist@v2
+  # cache-dependency-path defaults to manifest.yml
+- run: fontist manifest install manifest.yml
+```
 
-- **`cache-hit`:** Whether or not Fontist was restored from the runner's cache or newly downloaded.
+## Private formula repositories
 
-## Development
+To use private formula repositories hosted on GitHub, provide the `formula-repos` input with a list of repositories:
 
-![Bun](https://img.shields.io/static/v1?style=for-the-badge&message=Bun&color=000000&logo=Bun&logoColor=FFFFFF&label=)
-![Node.js](https://img.shields.io/static/v1?style=for-the-badge&message=Node.js&color=339933&logo=Node.js&logoColor=FFFFFF&label=)
-![Ruby](https://img.shields.io/static/v1?style=for-the-badge&message=Ruby&color=CC342D&logo=Ruby&logoColor=FFFFFF&label=)
+```yaml
+- uses: fontist/setup-fontist@v2
+  with:
+    # Uses the default GITHUB_TOKEN which has access to the current repo
+    # For cross-repo access, use a PAT with appropriate permissions
+    github-token: ${{ secrets.PRIVATE_FONTS_TOKEN }}
+    formula-repos: |
+      acme https://github.com/acme/fontist-formulas.git
+      corp https://github.com/corp/fonts.git
+- run: fontist install "Acme Custom Font"
+```
 
-This action tries to restore the result of `gem install fontist` from both the `$RUNNER_TOOL_CACHE` as well as the workflow cache via [@actions/cache](https://www.npmjs.com/package/@actions/cache). It then tries to restore the `~/.fontist` folder local cache from the workflow cache.
+> **Note:** `${{ github.token }}` is scoped to the current repository. To access private formula repositories in other organizations, you need to provide a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `repo` scope.
 
-**How do I test it?** \
-Open a PR (even a draft one works) and some magic GitHub Actions will run to test your changes.
+## Disable caching
 
-Note that since [Bun doesn't support Windows yet](https://github.com/oven-sh/bun/issues/43) we can't run the `bun build` command on Windows runners. Don't worry! The action should still work ok since Bun is only used for the build step; it runs using `node <the-js-file>` via `using: node20` in both testing and releases. Once Bun adds Windows support remember to add back the Windows tests. 😉
+```yaml
+- uses: fontist/setup-fontist@v2
+  with:
+    cache: false
+```
 
-## Contributions
+## Custom cache key
 
-This GitHub Action was originally created by @jcbhmr for the
-[Typst project](https://github.com/typst-community/typst.js)
-and contributed to [Fontist](https://www.fontist.org).
+By default, the `~/.fontist` cache key is derived from `manifest.yml` and `manifest.yaml`. You can customize this:
 
-Huge thanks to @jcbhmr for the tremendous effort in improving the Fontist
-ecosystem!
+```yaml
+- uses: fontist/setup-fontist@v2
+  with:
+    cache-dependency-path: |
+      fonts/requirements.yml
+      **/manifest.yml
+```
+
+# Outputs
+
+- **`fontist-version`:** The version of Fontist that was installed (e.g., `1.10.0`).
+- **`cache-hit`:** Whether Fontist was restored from cache (`true`) or newly downloaded (`false`).
+
+```yaml
+- uses: fontist/setup-fontist@v2
+  id: setup-fontist
+- run: echo "Installed Fontist ${{ steps.setup-fontist.outputs.fontist-version }}"
+```
+
+# Recommended permissions
+
+When using this action in your GitHub Actions workflow, it is recommended to set the following `GITHUB_TOKEN` permissions:
+
+```yaml
+permissions:
+  contents: read
+```
+
+If you're using the `cache` feature (enabled by default), you may also need:
+
+```yaml
+permissions:
+  contents: read
+  actions: read  # for cache restore
+  # actions: write  # for cache save (needed in some cases)
+```
+
+# Development
+
+This action is built with [Bun](https://bun.sh/) but runs on Node.js 20.
+
+```bash
+# Install dependencies
+bun install
+
+# Build the action (compiles src/main.ts and src/post.ts to dist/)
+bun run build
+
+# Type check
+bun run lint
+
+# Format code
+bun run format
+```
+
+**Testing:** Tests are run via GitHub Actions. Open a PR to trigger test runs across ubuntu-latest and macos-latest runners.
+
+Note: Since [Bun doesn't support Windows yet](https://github.com/oven-sh/bun/issues/43), we can't run `bun build` on Windows runners. However, the action still works on Windows since Bun is only used for the build step; it runs using Node.js via `using: node20`.
+
+# License
+
+The scripts and documentation in this project are released under the [MIT License](LICENSE).
+
+# Contributions
+
+This GitHub Action was originally created by @jcbhmr for the [Typst project](https://github.com/typst-community/typst.js) and contributed to [Fontist](https://www.fontist.org).
+
+Huge thanks to @jcbhmr for the tremendous effort in improving the Fontist ecosystem!

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,17 @@ inputs:
   fontist-version:
     description: The version of Fontist to install. This can be an exact version lile '1.10.0' or a semver range such as '1.x' or '~1.15.0'. The default value is 'latest'.
     default: latest
+  github-token:
+    description: GitHub token for accessing private formula repositories. Uses GITHUB_TOKEN by default.
+    default: ${{ github.token }}
+  formula-repos:
+    description: |
+      A multiline list of private Fontist formula repositories to set up.
+      Each line should be in format: NAME URL
+      Example:
+        acme https://github.com/acme/fontist-formulas.git
+        corp https://github.com/corp/fonts.git
+    default: ""
   cache:
     description: Whether or not to use @actions/cache to cache things in the GitHub workflow cache. This is enabled by default.
     default: true

--- a/dist/main.js
+++ b/dist/main.js
@@ -64478,6 +64478,13 @@ function saveCacheV2(paths_1, key_1, options_1) {
 
 // src/main.ts
 import assert5 from "node:assert/strict";
+var githubToken = getInput("github-token");
+if (githubToken) {
+  info("Configuring git to use GitHub token for github.com...");
+  await $`git config --global credential.helper store`;
+  await $`echo https://x-access-token:${githubToken}@github.com >> ~/.git-credentials`;
+  await $`git config --global url.https://x-access-token:${githubToken}@github.com/.insteadOf https://github.com/`;
+}
 var response = await fetch("https://rubygems.org/api/v1/versions/fontist.json");
 if (response.status !== 200) {
   throw new Error(`${response.url} returned ${response.status}`);
@@ -64570,5 +64577,17 @@ try {
   const formulasDir = join8(process.env.HOME, ".fontist", "versions", "v4", "formulas");
   await rm2(formulasDir, { recursive: true, force: true });
   await $({ stdio: "inherit" })`fontist update`;
+}
+var formulaRepos = getInput("formula-repos");
+if (formulaRepos) {
+  const repos = formulaRepos.trim().split(`
+`).filter(Boolean);
+  for (const line of repos) {
+    const [name, url2] = line.trim().split(/\s+/, 2);
+    if (name && url2) {
+      info(`Setting up formula repository: ${name} -> ${url2}`);
+      await $({ stdio: "inherit" })`fontist repo setup ${name} ${url2}`;
+    }
+  }
 }
 process.exit();

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,17 @@ import * as cache from "@actions/cache";
 import * as glob from "@actions/glob";
 import assert from "node:assert/strict";
 
+// Configure git to use GitHub token for github.com
+const githubToken = core.getInput("github-token");
+if (githubToken) {
+  core.info("Configuring git to use GitHub token for github.com...");
+  // Set up git credential helper for github.com
+  await $`git config --global credential.helper store`;
+  await $`echo https://x-access-token:${githubToken}@github.com >> ~/.git-credentials`;
+  // Also configure for submodules and other git operations
+  await $`git config --global url.https://x-access-token:${githubToken}@github.com/.insteadOf https://github.com/`;
+}
+
 const response = await fetch("https://rubygems.org/api/v1/versions/fontist.json");
 if (response.status !== 200) {
   throw new Error(`${response.url} returned ${response.status}`);
@@ -130,6 +141,19 @@ try {
   const formulasDir = join(process.env.HOME!, ".fontist", "versions", "v4", "formulas");
   await rm(formulasDir, { recursive: true, force: true });
   await $({ stdio: "inherit" })`fontist update`;
+}
+
+// Set up private formula repositories
+const formulaRepos = core.getInput("formula-repos");
+if (formulaRepos) {
+  const repos = formulaRepos.trim().split("\n").filter(Boolean);
+  for (const line of repos) {
+    const [name, url] = line.trim().split(/\s+/, 2);
+    if (name && url) {
+      core.info(`Setting up formula repository: ${name} -> ${url}`);
+      await $({ stdio: "inherit" })`fontist repo setup ${name} ${url}`;
+    }
+  }
 }
 
 // '@actions/cache' hangs unless we do this.


### PR DESCRIPTION
- Add `github-token` input for GitHub authentication (defaults to GITHUB_TOKEN)
- Add `formula-repos` input to set up private formula repositories  
- Configure git credentials to use token for github.com URLs
- Run `fontist repo setup` for each specified formula repo
- Add CI test for private repo functionality using metanorma formulas

Includes changes from #21 (RubyGems API instead of GitHub tags).