### PR TITLE
Upgrade to node24 runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See [issue #17](https://github.com/fontist/setup-fontist/issues/17) for more det
 
 # Development
 
-This action is built with [Bun](https://bun.sh/) but runs on Node.js 20.
+This action is built with [Bun](https://bun.sh/) but runs on Node.js 24.
 
 ```bash
 # Install dependencies
@@ -246,7 +246,7 @@ bun run format
 
 **Testing:** Tests are run via GitHub Actions. Open a PR to trigger test runs across ubuntu-latest and macos-latest runners.
 
-Note: Since [Bun doesn't support Windows yet](https://github.com/oven-sh/bun/issues/43), we can't run `bun build` on Windows runners. However, the action still works on Windows since Bun is only used for the build step; it runs using Node.js via `using: node20`.
+Note: Since [Bun doesn't support Windows yet](https://github.com/oven-sh/bun/issues/43), we can't run `bun build` on Windows runners. However, the action still works on Windows since Bun is only used for the build step; it runs using Node.js via `using: node24`.
 
 # License
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,6 @@ outputs:
     value: ${{ steps.setup-fontist.outputs.cache-hit }}
 
 runs:
-  using: node20
+  using: node24
   main: dist/main.js
   post: dist/post.js


### PR DESCRIPTION
Currently, when you run a workflow that uses setup-fontist, you get the following warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: fontist/setup-fontist@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I think this should be enough to update the runner to node24.